### PR TITLE
Fix usage of tls.TLSSocket

### DIFF
--- a/src/socket/socket_client_tcp.js
+++ b/src/socket/socket_client_tcp.js
@@ -5,10 +5,9 @@ const TIMEOUT = 10000
 
 class SocketClient {
   constructor(self, host, port, protocol, options) {
-    let conn
+    let conn = new net.Socket()
     switch (protocol) {
       case 'tcp':
-        conn = new net.Socket()
         break
       case 'tls':
       case 'ssl':
@@ -18,7 +17,7 @@ class SocketClient {
         } catch (e) {
           throw new Error('tls package could not be loaded')
         }
-        conn = new tls.TLSSocket(options)
+        conn = new tls.TLSSocket(conn, options)
         break
       default:
         throw new Error('not supported protocol', protocol)


### PR DESCRIPTION
The constructor of `tls.TLSSocket` requires a net.Socket (see [docs](https://nodejs.org/api/tls.html#tls_new_tls_tlssocket_socket_options)), which doesn't seem to be provided. This PR fixes this by changing the code to fit the node API.